### PR TITLE
scanner subscribed to network device request

### DIFF
--- a/public/components/devices/index.jsx
+++ b/public/components/devices/index.jsx
@@ -83,7 +83,10 @@ export class Devices extends React.Component {
 
   componentWillMount () {
     window.addEventListener('resize', this.handleResize)
+
+    this.mqtt.publish('network/devices/request')
     this.mqtt.subscribe('netbeast/network')
+
     this.mqtt.on('message', (topic, message) => {
       if (topic !== 'netbeast/network') return
 

--- a/src/services/scanner.js
+++ b/src/services/scanner.js
@@ -7,8 +7,20 @@ var broker = require('../helpers/broker')
 setInterval(function () {
   getArp()
 }, 6000)
+getInitArp();
 
 var cachedResult
+
+function getInitArp(){
+  broker.client.subscribe('network/devices/request')
+  broker.client.on('message', function(topic, message){
+    if (topic !== 'network/devices/request') return
+
+    if (cachedResult) {
+      broker.client.publish('netbeast/network', cachedResult)
+    }
+  })
+}
 
 function getArp () {
   Resource.find({}, function (err, devices) {
@@ -24,7 +36,7 @@ function getArp () {
       arp_str = data
     })
 
-    arp.on('error', function (err) { 
+    arp.on('error', function (err) {
       console.trace(err)
       broker.client.publish('netbeast/network', JSON.stringify(devices))
     })


### PR DESCRIPTION
Scanner subscribed to a `network/device/request` to which it responds with the cached list of devices in network.

The devices component publishes to it on `componentWillMount`